### PR TITLE
Login cookie changed name

### DIFF
--- a/geocachingsitelib.py
+++ b/geocachingsitelib.py
@@ -216,7 +216,7 @@ class GCSession(object):
         if _is_new_requests_lib():
             self.cookie_jar_ = r.cookies
             _debug_print("login cookies ",r.cookies)
-            login_ok = _did_request_succeed(r) and "gspkuserid" in r.cookies
+            login_ok = _did_request_succeed(r) and "gspkauth" in r.cookies
         else:
             login_ok = _did_request_succeed(r) and re.sub(r"<[^>]*>","",r.content).find('You are signed in as %s' % (self.gc_username)) > -1
         if not login_ok:


### PR DESCRIPTION
It seems that geocaching.com removed/renamed the `gspkuserid` cookie, which prevented gctools login. I've changed the login to look for the `gspkauth` cookie instead.

/Niels