### PR TITLE
Change name of username field

### DIFF
--- a/geocachingsitelib.py
+++ b/geocachingsitelib.py
@@ -210,7 +210,7 @@ class GCSession(object):
         post_data , formaction = _parse_for_hidden_inputs(gc_auth_uri_, r.content)
 
         post_data.update({
-            "Username":self.gc_username,
+            "UsernameOrEmail":self.gc_username,
             "Password":self.gc_password,
         })
 


### PR DESCRIPTION
The name of the login field has been changed on the geocaching website. With "Username", the login is impossible and we also have to use "UsernameOrEmail".

This might be related to #5 